### PR TITLE
fix: fixed getToken util

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -1,8 +1,7 @@
 function getToken (req) {
-  let token =
-    req.headers.authorization
-      ? req.headers.authorization.replace('Bearer', '')
-      : null
+  let token = req.headers.authorization
+    ? req.headers.authorization.split(" ")[1]
+    : null;
 
   return token && token.length ? token : null
 }


### PR DESCRIPTION
getToken previously returns token with a leading extra blank character, causing the token to be invalid